### PR TITLE
Make Papyrus Plugin compatible with next release of Notepad++ (with Lexilla)

### DIFF
--- a/src/Exports.def
+++ b/src/Exports.def
@@ -25,5 +25,5 @@ EXPORTS
   messageProc
   GetLexerCount
   GetLexerName
-  GetLexerStatusText
   GetLexerFactory
+  CreateLexer

--- a/src/Plugin/Lexer/LexerDefinition.cpp
+++ b/src/Plugin/Lexer/LexerDefinition.cpp
@@ -38,22 +38,18 @@ namespace papyrus {
     }
   }
 
-  void SCI_METHOD GetLexerStatusText(int index, TCHAR* text, int length) {
-    // From NPP's Parameters.h:
-    // #define MAX_EXTERNAL_LEXER_DESC_LEN 32
-    switch (index) {
-      case 0: {
-        wcsncpy_s(text, length, Lexer::statusText(), _TRUNCATE);
-        break;
-      }
-    }
-  }
-
   LexerFactoryFunction SCI_METHOD GetLexerFactory(int index) {
     switch (index) {
       case 0: {
         return Lexer::factory;
       }
+    }
+    return nullptr;
+  }
+
+  ILexer5* SCI_METHOD CreateLexer(const char* name) {
+    if (strcmp(name, Lexer::name()) == 0) {
+        return Lexer::factory();
     }
     return nullptr;
   }


### PR DESCRIPTION
- Remove GetLexerStatusText which is not needed anymore for next release of Notepad++, the name of lexer will be used directly.
- Add CreateLexer which is essential for every external lexer library for next release of Notepad++

Tested with the new modification of Notepad++ with Scintilla5 in PR:
https://github.com/notepad-plus-plus/notepad-plus-plus/pull/11468